### PR TITLE
update: ライブラリバージョンを最新に更新

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-certifi==2020.6.20
-chardet==3.0.4
-idna==2.10
-requests==2.24.0
+certifi==2025.11.12
+charset-normalizer==3.4.4
+idna==3.11
+requests==2.32.5
 slackweb==1.0.5
-urllib3==1.25.10
+urllib3==2.6.2


### PR DESCRIPTION
- certifi: 2020.6.20 → 2025.11.12
- chardet → charset-normalizer: 3.0.4 → 3.4.4
- idna: 2.10 → 3.11
- requests: 2.24.0 → 2.32.5
- urllib3: 1.25.10 → 2.6.2